### PR TITLE
Fix options loop to pull options in props

### DIFF
--- a/src/PlaceAutocompleteField.vue
+++ b/src/PlaceAutocompleteField.vue
@@ -132,11 +132,11 @@ export default {
                 input: this.getInputElement().value
             };
 
-            for (let i in API_REQUEST_OPTIONS) {
-                if (this[i] !== undefined || this[i] !== null) {
-                    options[i] = this[i];
+            API_REQUEST_OPTIONS.forEach(prop => {
+                if (this[prop] !== undefined || this[prop] !== null) {
+                    options[prop] = this[prop];
                 }
-            }
+            });
 
             return options;
         },


### PR DESCRIPTION
Hey! We're using this on a project and ran into a little bug when trying to add `types` options. Idk if this has always been the case, but using the for loop was only returning the index of the option and in the array and not the key.

Hopefully this should be a quick and easy thing to merge in? As it is, I believe this is broken for everyone, though admittedly, they might be relying on that broken implementation.

Thanks!