### PR TITLE
Restrict predictions by component restrictions 

### DIFF
--- a/src/PlaceAutocompleteField.vue
+++ b/src/PlaceAutocompleteField.vue
@@ -41,7 +41,7 @@ const KEYCODE = {
 const API_REQUEST_OPTIONS = [
     'bounds',
     'location',
-    'component-restrictions',
+    'componentRestrictions',
     'offset',
     'radius',
     'types'


### PR DESCRIPTION
According to the AutocompletionRequest interface (https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest) component-restrictions should renamed to componentRestrictions.

Fixes: #6